### PR TITLE
Update dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "description": "Helper script to diff lint output files",
     "author": "Joseph P. White <jpwhite4@buffalo.edu>",
     "dependencies": {
-        "diff": "3.2.x",
-        "colors": "1.1.x"
+        "diff": "5.1.x",
+        "colors": "1.4.x"
     },
     "engine": "node >= 0.10.25"
 }


### PR DESCRIPTION
Updated `diff` and `colors` to latest. Used existing tests to check for breaking changes.

[Diff](https://github.com/kpdecker/jsdiff) added BSD license in 4.0.0. I am unsure if we need to adding anything because of that.