### PR TITLE
Fix comparison on eslint messages

### DIFF
--- a/lint-diff.js
+++ b/lint-diff.js
@@ -57,13 +57,17 @@ var process_lintfile = function(filename) {
         // eslint does not return the json errors in a deterministic order
         // so sort the errors before processing.
         var comparison = function(a, b) {
-            var properties = ['line', 'column', 'severity', 'message', 'messageId', 'ruleId'];
+            var properties = ['line', 'column', 'severity', 'message', 'ruleId'];
             var i, result = 0;
             for (i = 0; result === 0 && i < properties.length; i++) {
                 result = compare(a[properties[i]],  b[properties[i]]);
             }
             return result;
         };
+
+        report[0].messages.forEach((elem) => {
+            elem.message = elem.message.replaceAll(/on line \d+ column \d+/g, '');
+        });
 
         report[0].messages.sort(comparison);
 
@@ -75,12 +79,7 @@ var process_lintfile = function(filename) {
                 type: message.severity > 1 ? 'error' : 'warning',
                 message: message.message + ' (' + message.ruleId + ')'
             });
-            if (message.message.includes('on line')) {
-                output.messages.push(message.ruleId + message.severity + message.messageId);
-            }
-            else {
-                output.messages.push(message.ruleId + message.severity + message.message + message.messageId);
-            }
+            output.messages.push(message.ruleId + message.severity + message.message);
         }
         return output;
     }

--- a/lint-diff.js
+++ b/lint-diff.js
@@ -75,7 +75,7 @@ var process_lintfile = function(filename) {
                 type: message.severity > 1 ? 'error' : 'warning',
                 message: message.message + ' (' + message.ruleId + ')'
             });
-            output.messages.push(message.ruleId + message.severity + message.source + message.message);
+            output.messages.push(message.ruleId + message.severity + message.source + message.messageId);
         }
         return output;
     }

--- a/lint-diff.js
+++ b/lint-diff.js
@@ -75,7 +75,12 @@ var process_lintfile = function(filename) {
                 type: message.severity > 1 ? 'error' : 'warning',
                 message: message.message + ' (' + message.ruleId + ')'
             });
-            output.messages.push(message.ruleId + message.severity + message.source + message.messageId);
+            if (message.message.includes('on line')) {
+                output.messages.push(message.ruleId + message.severity + message.messageId);
+            }
+            else {
+                output.messages.push(message.ruleId + message.severity + message.message + message.messageId);
+            }
         }
         return output;
     }

--- a/lint-diff.js
+++ b/lint-diff.js
@@ -57,7 +57,7 @@ var process_lintfile = function(filename) {
         // eslint does not return the json errors in a deterministic order
         // so sort the errors before processing.
         var comparison = function(a, b) {
-            var properties = ['line', 'column', 'severity', 'message', 'ruleId'];
+            var properties = ['line', 'column', 'severity', 'message', 'messageId', 'ruleId'];
             var i, result = 0;
             for (i = 0; result === 0 && i < properties.length; i++) {
                 result = compare(a[properties[i]],  b[properties[i]]);


### PR DESCRIPTION
These changes are for the eslint mode portion of the code. `diffArrays` can throw false positives when the message contains line number information.

Changed `message.message`  &#8594; `message.messageId`

**ESLint message structure:**
- ruleId
- severity
- message
- line
- column
- nodeType
- messageId
- endLine
- endColumn
- fix